### PR TITLE
Prevent error if iso is given without a folder

### DIFF
--- a/pve-iso-2-pxe.sh
+++ b/pve-iso-2-pxe.sh
@@ -17,7 +17,7 @@ if [ ! $# -eq 1 ]; then
   exit
 fi
 
-BASEDIR=${1:-./}
+BASEDIR="$(dirname "$(readlink -f "$1")")"
 pushd $BASEDIR >/dev/null
 
 [ -L "proxmox.iso" ] && rm proxmox.iso &>/dev/null


### PR DESCRIPTION
This change should make the BASEDIR detection much more robust by first detecting the full path to the iso (with readlink) and computing the basedir path from that (dirname).