### PR TITLE
feat: Containerise, and use the auto-install-assistant to parse answer files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+# Generated files
+/output/
+*.iso
+answers.toml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,41 @@
+FROM debian:bookworm-slim
+
+ENV DEBIAN_FRONTEND=noninteractive
+WORKDIR /tmp
+
+# Install dependencies
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    cpio \
+    file \
+    zstd \
+    gzip \
+    wget \
+    git \
+    genisoimage \
+    gnupg \
+    apt-transport-https \
+    xorriso && \
+    rm -rf /var/lib/apt/lists/*
+
+# Add Proxmox repository and install proxmox-auto-install-assistant
+RUN echo "deb http://download.proxmox.com/debian/pve bookworm pve-no-subscription" > /etc/apt/sources.list.d/pve.list && \
+    wget -qO- http://download.proxmox.com/debian/proxmox-release-bookworm.gpg | \
+    gpg --dearmor > /etc/apt/trusted.gpg.d/proxmox-release-bookworm.gpg && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends proxmox-auto-install-assistant && \
+    rm -rf /var/lib/apt/lists/*
+
+# Fetch the PXE generation script
+RUN mkdir -p /tmp/pve-iso-2-pxe && \
+    GIT_SSL_NO_VERIFY=true git clone https://github.com/joelstoddard/pve-auto-install-pxe.git /tmp/pve-auto-install-pxe && \
+    chmod +x /tmp/pve-auto-install-pxe/pve-iso-2-pxe.sh
+
+# Create directories for volume mounts
+RUN mkdir -p /tmp/input /tmp/output
+
+# Create a wrapper script that performs the operations
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -16,11 +16,22 @@
 
 ## Preparation
 
-* install `cpio file zstd gzip genisoimage` packages
-* download **Proxmox VE ISO Installer** from [Proxmox](http://proxmox.com/downloads) into a folder somewhere (e.g. `~/Downloads/proxmox-ve_6.4-1.iso`)
-* run the script `pve-iso-2-pxe.sh` with the path to the ISO file as parameter
-  * `bash pve-iso-2-pxe.sh ~/Downloads/proxmox-ve_6.4-1.iso`
-* the `linux26` and `initrd` (including ISO) will copied to the sub-directory `pxeboot` located relative to the iso file (e.g. `~/Downloads/pxeboot`)
+* Install Docker
+* download **Proxmox VE ISO Installer** from [Proxmox](http://proxmox.com/downloads)
+* Insert your `answers.toml`.
+* Build the container
+```bash
+docker build --platform linux/amd64 -t pve-auto-install-pxe . --no-cache
+```
+* Run the container
+```bash
+docker run -it --platform linux/amd64 \
+-v /path/to/answers.toml:/tmp/input/answers.toml \
+-v /path/to/proxmox.iso:/tmp/input/proxmox.iso \
+-v ./output:/tmp/output \
+pve-auto-install-pxe
+```
+* the `linux26` and `initrd` (including ISO) will be copied to the sub-directory `pxeboot` located relative to the iso file
 
 ## [iPXE](https://ipxe.org/) (recommended)
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+set -eo pipefail
+
+# Check for required files
+if [ -f "/tmp/input/answers.toml" ] && [ -f "/tmp/input/proxmox.iso" ]; then
+    echo "Found answers.toml and ISO. Processing..."
+    
+    # Generate custom ISO with proxmox-auto-install-assistant
+    echo "Generating custom auto install Proxmox ISO with options from provided answers.toml..."
+    proxmox-auto-install-assistant prepare-iso \
+        /tmp/input/proxmox.iso \
+        --fetch-from iso \
+        --answer-file /tmp/input/answers.toml \
+        --output /tmp/pve-auto-install-pxe.iso
+    
+    # Verify ISO was created
+    if [ -f "/tmp/pve-auto-install-pxe.iso" ]; then
+        echo "Successfully generated headless Proxmox ISO"
+        
+        # Convert to PXE format
+        echo "Converting ISO to PXE format..."
+        /tmp/pve-auto-install-pxe/pve-iso-2-pxe.sh /tmp/pve-auto-install-pxe.iso
+        
+        # Copy PXE files to output directory
+        if [ -d "/tmp/output" ]; then
+            echo "Copying PXE files & ISO to output directory..."
+            cp -r /tmp/pxeboot/* /tmp/pve-auto-install-pxe.iso /tmp/output/
+            echo "PXE files copied to output directory"
+        fi
+    else
+        echo "Error: Failed to generate custom Proxmox ISO"
+    fi
+else
+    echo "Missing required input files:"
+    [ ! -f "/tmp/input/answers.toml" ] && echo " - answers.toml not found in /tmp/input/"
+    [ ! -f "/tmp/input/proxmox.iso" ] && echo " - An iso file not found in /tmp/input/"
+fi


### PR DESCRIPTION
I have need to be able to use this script to generate the PXE files but I needed to input the `answers.toml` files as per the documentation [here](https://pve.proxmox.com/wiki/Automated_Installation), and wanted to containerise this for portability. 

Updated usage documentation is included in the README.md. 